### PR TITLE
fix: use Alfred data directory for persistent cache

### DIFF
--- a/bdd_test.go
+++ b/bdd_test.go
@@ -215,7 +215,7 @@ func (ctx *BDDContext) iShouldSeeAHumanReadableTimeFormat() error {
 	}
 	
 	// Check for basic time format elements
-	if !strings.Contains(ctx.outputTime, "2025") {
+	if !strings.Contains(ctx.outputTime, time.Now().Format("2006")) {
 		return fmt.Errorf("expected current year in time output: %s", ctx.outputTime)
 	}
 	
@@ -312,7 +312,7 @@ func (ctx *BDDContext) theExitCodeShouldBe(expectedCode int) error {
 }
 
 func (ctx *BDDContext) theOutputShouldContainTheCurrentDateAndTime() error {
-	if !strings.Contains(ctx.commandOutput, "2025") {
+	if !strings.Contains(ctx.commandOutput, time.Now().Format("2006")) {
 		return fmt.Errorf("expected current year in output")
 	}
 	return nil

--- a/cmd/geotz/main.go
+++ b/cmd/geotz/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -33,9 +34,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Fast path: Check cache first before initializing expensive dependencies
-	// Always use geotz_cache.json in current directory
-	cacheAdapter := cache.NewLRUCache(1000, 30*24*time.Hour, ".")
+	// Use Alfred's persistent data dir when available, fall back to CWD for standalone CLI
+	cacheDir := resolveCacheDir()
+	if cacheDir != "." {
+		seedFromWorkflowDir(cacheDir)
+	}
+	cacheAdapter := cache.NewLRUCache(1000, 30*24*time.Hour, cacheDir)
 	cacheKey := strings.ToLower(city)
 	if tz, ok := cacheAdapter.Get(cacheKey); ok {
 		// Cache hit - skip expensive validation, just format and output
@@ -86,6 +90,31 @@ func main() {
 	}
 
 	os.Stdout.Write(output)
+}
+
+// resolveCacheDir returns the directory for runtime cache storage.
+// Inside Alfred: uses alfred_workflow_data (persistent across updates).
+// Outside Alfred: falls back to current directory.
+func resolveCacheDir() string {
+	if dir := os.Getenv("alfred_workflow_data"); dir != "" {
+		return dir
+	}
+	return "."
+}
+
+// seedFromWorkflowDir copies the shipped pre-seeded cache to the data directory
+// on first run. No-op if the data dir cache already exists.
+func seedFromWorkflowDir(dataDir string) {
+	dest := filepath.Join(dataDir, "geotz_cache.json")
+	if _, err := os.Stat(dest); err == nil {
+		return
+	}
+	src, err := os.ReadFile(filepath.Join(".", "geotz_cache.json"))
+	if err != nil {
+		return
+	}
+	os.MkdirAll(dataDir, 0755)
+	os.WriteFile(dest, src, 0644)
 }
 
 func outputError(msg string, format string) {

--- a/cmd/geotz/main_test.go
+++ b/cmd/geotz/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -117,5 +118,70 @@ func TestGeotz_InvalidCity_Plain(t *testing.T) {
 	result := string(out)
 	if !strings.Contains(strings.ToLower(result), "could not geocode") {
 		t.Errorf("expected error message in stderr, got: %v", result)
+	}
+}
+
+func TestResolveCacheDir_WithEnvVar(t *testing.T) {
+	t.Setenv("alfred_workflow_data", "/tmp/test-workflow-data")
+	if dir := resolveCacheDir(); dir != "/tmp/test-workflow-data" {
+		t.Errorf("expected env var path, got %s", dir)
+	}
+}
+
+func TestResolveCacheDir_WithoutEnvVar(t *testing.T) {
+	t.Setenv("alfred_workflow_data", "")
+	if dir := resolveCacheDir(); dir != "." {
+		t.Errorf("expected '.', got %s", dir)
+	}
+}
+
+func TestSeedFromWorkflowDir_CopiesWhenMissing(t *testing.T) {
+	workflowDir := t.TempDir()
+	dataDir := t.TempDir()
+
+	os.WriteFile(filepath.Join(workflowDir, "geotz_cache.json"), []byte(`{"max":1000,"cache":[]}`), 0644)
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(workflowDir)
+	defer os.Chdir(oldWd)
+
+	seedFromWorkflowDir(dataDir)
+
+	if _, err := os.Stat(filepath.Join(dataDir, "geotz_cache.json")); os.IsNotExist(err) {
+		t.Error("expected cache file to be copied to data dir")
+	}
+}
+
+func TestSeedFromWorkflowDir_SkipsWhenExists(t *testing.T) {
+	workflowDir := t.TempDir()
+	dataDir := t.TempDir()
+
+	os.WriteFile(filepath.Join(workflowDir, "geotz_cache.json"), []byte(`{"max":1000,"cache":[["src",{}]]}`), 0644)
+	os.WriteFile(filepath.Join(dataDir, "geotz_cache.json"), []byte(`{"max":1000,"cache":[["dest",{}]]}`), 0644)
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(workflowDir)
+	defer os.Chdir(oldWd)
+
+	seedFromWorkflowDir(dataDir)
+
+	data, _ := os.ReadFile(filepath.Join(dataDir, "geotz_cache.json"))
+	if !strings.Contains(string(data), "dest") {
+		t.Error("expected existing data-dir cache to be preserved")
+	}
+}
+
+func TestSeedFromWorkflowDir_NoSourceCache(t *testing.T) {
+	workflowDir := t.TempDir() // empty, no cache file
+	dataDir := t.TempDir()
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(workflowDir)
+	defer os.Chdir(oldWd)
+
+	seedFromWorkflowDir(dataDir)
+
+	if _, err := os.Stat(filepath.Join(dataDir, "geotz_cache.json")); !os.IsNotExist(err) {
+		t.Error("expected no cache file in data dir when source is missing")
 	}
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -39,7 +39,7 @@ func TestUserCanGetCurrentTimeInKnownCity(t *testing.T) {
 	}
 	
 	// The time should be in human-readable format and current
-	if !strings.Contains(timeString, "2025") {
+	if !strings.Contains(timeString, time.Now().Format("2006")) {
 		t.Errorf("Expected time to contain current year, got '%s'", timeString)
 	}
 	
@@ -198,7 +198,7 @@ func TestPipelineWorkflowWorksEndToEnd(t *testing.T) {
 	result := strings.TrimSpace(string(output))
 	
 	// Should get current time in Berlin timezone
-	if !strings.Contains(result, "2025") {
+	if !strings.Contains(result, time.Now().Format("2006")) {
 		t.Errorf("Expected current year in result, got '%s'", result)
 	}
 	

--- a/internal/adapters/presenter/plain_test.go
+++ b/internal/adapters/presenter/plain_test.go
@@ -3,6 +3,7 @@ package presenter
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/loginx/alfred-timein/internal/domain"
 )
@@ -47,7 +48,7 @@ func TestPlainFormatter_ShouldFormatTimeInfoAsHumanReadable(t *testing.T) {
 	}
 	
 	// Should contain readable date format
-	if !strings.Contains(result, "2025") {
+	if !strings.Contains(result, time.Now().Format("2006")) {
 		t.Error("Expected output to contain current year")
 	}
 	


### PR DESCRIPTION
## Summary
- Reads `alfred_workflow_data` env var at runtime to store cache in Alfred's persistent data directory
- Seeds from shipped pre-seeded cache on first run (copies workflow-dir cache to data dir)
- Falls back to CWD when running outside Alfred (standalone CLI)
- Prevents user-accumulated cache entries from being destroyed on workflow updates

## Test plan
- [x] Unit tests for `resolveCacheDir` (with/without env var)
- [x] Unit tests for `seedFromWorkflowDir` (copies when missing, skips when exists, handles missing source)
- [x] Manual: `alfred_workflow_data=/tmp/test-data ./bin/geotz London` writes to data dir