### PR TITLE
feat: add modifier keys, icons, and Universal Actions

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -114,17 +114,16 @@ Search for the current local time in any city via the `timein` keyword.
 
 ![Showing timein workflow in action](screenshot.png)
 
-Type:
+* ⏎ Copy full time string to clipboard
+* ⌘⏎ Copy timezone name only (e.g. Asia/Bangkok)
+* ⌥⏎ Copy ISO 8601 time
+* ⌘L Large Type display
+
+## Examples
 
     timein bangkok
     timein new york
     timein tokyo
-
-And get:
-
-    Asia/Bangkok (UTC+7)  Fri, May 2, 9:30 AM
-
-## Description
 
 A fast, zero-config Alfred workflow that tells you the current local time in any city using natural language input.</string>
 	<key>uidata</key>

--- a/internal/adapters/presenter/alfred.go
+++ b/internal/adapters/presenter/alfred.go
@@ -9,7 +9,11 @@ import (
 	"github.com/tkuchiki/go-timezone"
 )
 
-const alfredCacheSeconds = 604800 // 7 days
+const (
+	alfredCacheSeconds = 604800 // 7 days
+	workflowIcon       = "icon.png"
+	errorIcon          = "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/AlertStopIcon.icns"
+)
 
 // AlfredFormatter formats output for Alfred Script Filter
 type AlfredFormatter struct{}
@@ -33,6 +37,7 @@ func (f *AlfredFormatter) FormatTimezoneInfo(timezone *domain.Timezone, city str
 		Title:    timezone.String(),
 		Subtitle: subtitle,
 		Arg:      timezone.String(),
+		Icon:     &alfred.Icon{Path: workflowIcon},
 		Variables: map[string]interface{}{
 			"city": city,
 		},
@@ -62,6 +67,7 @@ func (f *AlfredFormatter) FormatTimeInfo(tz *domain.Timezone) ([]byte, error) {
 
 	title := fmt.Sprintf("%s - %s", tz.String(), now.Format("Mon, Jan 2, 3:04 PM"))
 	subtitle := fmt.Sprintf("Current time in %s (%s)", city, abbr)
+	iso8601 := now.Format(time.RFC3339)
 
 	out := alfred.NewScriptFilterOutput()
 	out.Cache = &alfred.CacheConfig{Seconds: 60}
@@ -71,6 +77,13 @@ func (f *AlfredFormatter) FormatTimeInfo(tz *domain.Timezone) ([]byte, error) {
 		Title:    title,
 		Subtitle: subtitle,
 		Arg:      title,
+		Icon:     &alfred.Icon{Path: workflowIcon},
+		Text:     &alfred.Text{Copy: title, LargeType: title},
+		Action:   title,
+		Mods: map[string]alfred.Mod{
+			"cmd": {Subtitle: "Copy timezone", Arg: tz.String()},
+			"alt": {Subtitle: "Copy ISO 8601 time", Arg: iso8601},
+		},
 		Variables: map[string]interface{}{
 			"timezone": tz.String(),
 		},
@@ -87,6 +100,7 @@ func (f *AlfredFormatter) FormatError(message string) ([]byte, error) {
 		Title:    "Error",
 		Subtitle: message,
 		Valid:    boolPtr(false),
+		Icon:     &alfred.Icon{Path: errorIcon},
 	}
 	out.AddItem(item)
 	return out.ToJSON()

--- a/internal/adapters/presenter/alfred_test.go
+++ b/internal/adapters/presenter/alfred_test.go
@@ -8,83 +8,74 @@ import (
 )
 
 func TestAlfredFormatter_ShouldFormatValidTimezoneInfoWithCache(t *testing.T) {
-	// Given an Alfred formatter and a timezone
 	formatter := NewAlfredFormatter()
 	timezone, _ := domain.NewTimezone("Europe/Paris")
-	
-	// When formatting timezone info with cached flag
+
 	output, err := formatter.FormatTimezoneInfo(timezone, "Paris", true)
-	
-	// Then it should produce valid Alfred JSON
 	if err != nil {
 		t.Fatalf("Expected successful formatting, got error: %v", err)
 	}
-	
+
 	var result map[string]interface{}
 	if err := json.Unmarshal(output, &result); err != nil {
 		t.Fatalf("Expected valid JSON, got error: %v", err)
 	}
-	
-	// And it should contain the expected structure
+
 	items := result["items"].([]interface{})
 	if len(items) != 1 {
 		t.Fatalf("Expected 1 item, got %d", len(items))
 	}
-	
+
 	item := items[0].(map[string]interface{})
-	
-	// Title should be the timezone
+
 	if item["title"] != "Europe/Paris" {
 		t.Errorf("Expected title 'Europe/Paris', got '%v'", item["title"])
 	}
-	
-	// Subtitle should indicate it's cached
+
 	subtitle := item["subtitle"].(string)
 	if !contains(subtitle, "Paris") || !contains(subtitle, "cached") {
 		t.Errorf("Expected subtitle to contain 'Paris' and 'cached', got '%s'", subtitle)
 	}
-	
-	// Should have cache configuration
+
 	cache := result["cache"].(map[string]interface{})
-	if cache["seconds"].(float64) != 604800 { // 7 days
+	if cache["seconds"].(float64) != 604800 {
 		t.Errorf("Expected cache seconds to be 604800, got %v", cache["seconds"])
+	}
+
+	// Should have workflow icon
+	icon := item["icon"].(map[string]interface{})
+	if icon["path"] != "icon.png" {
+		t.Errorf("Expected icon path 'icon.png', got '%v'", icon["path"])
 	}
 }
 
 func TestAlfredFormatter_ShouldFormatTimeInfoWithAbbreviation(t *testing.T) {
-	// Given an Alfred formatter and a timezone
 	formatter := NewAlfredFormatter()
 	timezone, _ := domain.NewTimezone("America/New_York")
-	
-	// When formatting time info
+
 	output, err := formatter.FormatTimeInfo(timezone)
-	
-	// Then it should produce valid Alfred JSON with time
 	if err != nil {
 		t.Fatalf("Expected successful formatting, got error: %v", err)
 	}
-	
+
 	var result map[string]interface{}
 	if err := json.Unmarshal(output, &result); err != nil {
 		t.Fatalf("Expected valid JSON, got error: %v", err)
 	}
-	
+
 	items := result["items"].([]interface{})
 	item := items[0].(map[string]interface{})
-	
-	// Title should contain timezone and formatted time
+
 	title := item["title"].(string)
 	if !contains(title, "America/New_York") {
 		t.Errorf("Expected title to contain timezone, got '%s'", title)
 	}
-	
-	// Subtitle should contain city and timezone abbreviation
+
 	subtitle := item["subtitle"].(string)
 	if !contains(subtitle, "New York") {
 		t.Errorf("Expected subtitle to contain 'New York', got '%s'", subtitle)
 	}
-	
-	// Should have shorter cache (60 seconds for time)
+
 	cache := result["cache"].(map[string]interface{})
 	if cache["seconds"].(float64) != 60 {
 		t.Errorf("Expected cache seconds to be 60, got %v", cache["seconds"])
@@ -94,41 +85,70 @@ func TestAlfredFormatter_ShouldFormatTimeInfoWithAbbreviation(t *testing.T) {
 	if result["skipknowledge"] != true {
 		t.Errorf("Expected skipknowledge to be true, got %v", result["skipknowledge"])
 	}
+
+	// Should have workflow icon
+	icon := item["icon"].(map[string]interface{})
+	if icon["path"] != "icon.png" {
+		t.Errorf("Expected icon path 'icon.png', got '%v'", icon["path"])
+	}
+
+	// Should have text for CMD+C and CMD+L
+	text := item["text"].(map[string]interface{})
+	if text["copy"] != title {
+		t.Errorf("Expected text.copy to match title")
+	}
+	if text["largetype"] != title {
+		t.Errorf("Expected text.largetype to match title")
+	}
+
+	// Should have modifier keys
+	mods := item["mods"].(map[string]interface{})
+	cmdMod := mods["cmd"].(map[string]interface{})
+	if cmdMod["arg"] != "America/New_York" {
+		t.Errorf("Expected cmd mod arg to be timezone, got '%v'", cmdMod["arg"])
+	}
+	altMod := mods["alt"].(map[string]interface{})
+	altArg := altMod["arg"].(string)
+	if !contains(altArg, "T") || !contains(altArg, "-") {
+		t.Errorf("Expected alt mod arg to be ISO 8601, got '%s'", altArg)
+	}
+
+	// Should have Universal Action
+	if item["action"] == nil {
+		t.Error("Expected action field to be set")
+	}
 }
 
 func TestAlfredFormatter_ShouldFormatErrorsAsInvalidItems(t *testing.T) {
-	// Given an Alfred formatter and an error message
 	formatter := NewAlfredFormatter()
-	
-	// When formatting an error
+
 	output, err := formatter.FormatError("Something went wrong")
-	
-	// Then it should produce valid Alfred JSON
 	if err != nil {
 		t.Fatalf("Expected successful error formatting, got error: %v", err)
 	}
-	
+
 	var result map[string]interface{}
 	if err := json.Unmarshal(output, &result); err != nil {
 		t.Fatalf("Expected valid JSON, got error: %v", err)
 	}
-	
+
 	items := result["items"].([]interface{})
 	item := items[0].(map[string]interface{})
-	
-	// Should be marked as an error
+
 	if item["title"] != "Error" {
 		t.Errorf("Expected title 'Error', got '%v'", item["title"])
 	}
-	
-	// Should contain the error message
 	if item["subtitle"] != "Something went wrong" {
 		t.Errorf("Expected subtitle 'Something went wrong', got '%v'", item["subtitle"])
 	}
-	
-	// Should be marked as invalid (not actionable)
 	if item["valid"] != false {
 		t.Errorf("Expected valid to be false for errors, got %v", item["valid"])
+	}
+
+	// Should have system error icon
+	icon := item["icon"].(map[string]interface{})
+	if !contains(icon["path"].(string), "AlertStopIcon") {
+		t.Errorf("Expected error icon, got '%v'", icon["path"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add modifier keys: ⌘⏎ copies timezone name, ⌥⏎ copies ISO 8601 time
- Add workflow icon on result items and system error icon on error items
- Add `text.copy`/`text.largetype` for CMD+C and CMD+L support
- Add Universal Action payload for chaining results into other workflows
- Update info.plist readme with modifier key documentation

## Test plan
- [x] Unit tests verify icon, text, mods, and action fields on all item types
- [x] Manual: `echo "America/New_York" | ./bin/timein --format=alfred | jq .` shows enriched output
- [x] Manual: verify modifier keys work in Alfred