### PR TITLE
feat: add user-configurable keyword and skipknowledge

### DIFF
--- a/bdd_test.go
+++ b/bdd_test.go
@@ -215,7 +215,7 @@ func (ctx *BDDContext) iShouldSeeAHumanReadableTimeFormat() error {
 	}
 	
 	// Check for basic time format elements
-	if !strings.Contains(ctx.outputTime, "2025") {
+	if !strings.Contains(ctx.outputTime, time.Now().Format("2006")) {
 		return fmt.Errorf("expected current year in time output: %s", ctx.outputTime)
 	}
 	
@@ -312,7 +312,7 @@ func (ctx *BDDContext) theExitCodeShouldBe(expectedCode int) error {
 }
 
 func (ctx *BDDContext) theOutputShouldContainTheCurrentDateAndTime() error {
-	if !strings.Contains(ctx.commandOutput, "2025") {
+	if !strings.Contains(ctx.commandOutput, time.Now().Format("2006")) {
 		return fmt.Errorf("expected current year in output")
 	}
 	return nil

--- a/info.plist
+++ b/info.plist
@@ -67,7 +67,7 @@
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>keyword</key>
-				<string>timein</string>
+				<string>{var:keyword}</string>
 				<key>queuedelaycustom</key>
 				<integer>3</integer>
 				<key>queuedelayimmediatelyinitially</key>
@@ -145,7 +145,29 @@ A fast, zero-config Alfred workflow that tells you the current local time in any
 		</dict>
 	</dict>
 	<key>userconfigurationconfig</key>
-	<array/>
+	<array>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>timein</string>
+				<key>placeholder</key>
+				<string>timein</string>
+				<key>required</key>
+				<true/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>Keyword to trigger the workflow</string>
+			<key>label</key>
+			<string>Keyword</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>keyword</string>
+		</dict>
+	</array>
 	<key>variablesdontexport</key>
 	<array/>
 	<key>version</key>

--- a/integration_test.go
+++ b/integration_test.go
@@ -39,7 +39,7 @@ func TestUserCanGetCurrentTimeInKnownCity(t *testing.T) {
 	}
 	
 	// The time should be in human-readable format and current
-	if !strings.Contains(timeString, "2025") {
+	if !strings.Contains(timeString, time.Now().Format("2006")) {
 		t.Errorf("Expected time to contain current year, got '%s'", timeString)
 	}
 	
@@ -198,7 +198,7 @@ func TestPipelineWorkflowWorksEndToEnd(t *testing.T) {
 	result := strings.TrimSpace(string(output))
 	
 	// Should get current time in Berlin timezone
-	if !strings.Contains(result, "2025") {
+	if !strings.Contains(result, time.Now().Format("2006")) {
 		t.Errorf("Expected current year in result, got '%s'", result)
 	}
 	

--- a/internal/adapters/presenter/alfred.go
+++ b/internal/adapters/presenter/alfred.go
@@ -65,6 +65,7 @@ func (f *AlfredFormatter) FormatTimeInfo(tz *domain.Timezone) ([]byte, error) {
 
 	out := alfred.NewScriptFilterOutput()
 	out.Cache = &alfred.CacheConfig{Seconds: 60}
+	out.SkipKnowledge = true
 
 	item := alfred.Item{
 		Title:    title,

--- a/internal/adapters/presenter/alfred_test.go
+++ b/internal/adapters/presenter/alfred_test.go
@@ -89,6 +89,11 @@ func TestAlfredFormatter_ShouldFormatTimeInfoWithAbbreviation(t *testing.T) {
 	if cache["seconds"].(float64) != 60 {
 		t.Errorf("Expected cache seconds to be 60, got %v", cache["seconds"])
 	}
+
+	// Should preserve result ordering
+	if result["skipknowledge"] != true {
+		t.Errorf("Expected skipknowledge to be true, got %v", result["skipknowledge"])
+	}
 }
 
 func TestAlfredFormatter_ShouldFormatErrorsAsInvalidItems(t *testing.T) {

--- a/internal/adapters/presenter/plain_test.go
+++ b/internal/adapters/presenter/plain_test.go
@@ -3,6 +3,7 @@ package presenter
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/loginx/alfred-timein/internal/domain"
 )
@@ -47,7 +48,7 @@ func TestPlainFormatter_ShouldFormatTimeInfoAsHumanReadable(t *testing.T) {
 	}
 	
 	// Should contain readable date format
-	if !strings.Contains(result, "2025") {
+	if !strings.Contains(result, time.Now().Format("2006")) {
 		t.Error("Expected output to contain current year")
 	}
 	


### PR DESCRIPTION
## Summary
- Add `userconfigurationconfig` entry for keyword (default: `timein`, user can change in Alfred Preferences)
- Replace hardcoded `timein` keyword with `{var:keyword}` variable reference
- Set `skipknowledge: true` on time results to preserve stable ordering

## Test plan
- [x] Unit test verifies `skipknowledge` in FormatTimeInfo output
- [x] `plutil -lint info.plist` passes
- [x] Manual: import workflow, verify Configuration panel shows keyword field
- [x] Manual: change keyword, verify it triggers with new keyword